### PR TITLE
Add avatar prefetch and early theme class script

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,6 +3,7 @@ import { SpeedInsights } from "@vercel/speed-insights/next";
 import type { Metadata } from "next";
 import localFont from "next/font/local";
 import { ThemeProvider } from "../providers/ThemeProvider";
+import Script from "next/script";
 import "./globals.css";
 
 const geistSans = localFont({
@@ -28,6 +29,22 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en" suppressHydrationWarning>
+      <head>
+        <Script id="theme-script" strategy="beforeInteractive">
+          {`
+            (function() {
+              try {
+                var theme = localStorage.getItem('theme') || 'dark';
+                if (theme === 'system') {
+                  var dark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+                  theme = dark ? 'dark' : 'light';
+                }
+                document.documentElement.classList.add(theme);
+              } catch (e) {}
+            })();
+          `}
+        </Script>
+      </head>
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased bg-background dark:bg-background-dark text-foreground dark:text-foreground-dark`}
       >

--- a/components/about/Avatar.tsx
+++ b/components/about/Avatar.tsx
@@ -8,7 +8,12 @@ const hoverEffect = { scale: 1.1 };
 const Avatar = () => (
   <motion.div className="hidden lg:block" whileHover={hoverEffect}>
     <div className="w-64 h-64 rounded-full border-2 border-ring dark:border-ring-dark overflow-hidden">
-      <Image src={pro} alt="Alex Frank" className="object-cover w-full h-full" />
+      <Image
+        src={pro}
+        alt="Alex Frank"
+        priority
+        className="object-cover w-full h-full"
+      />
     </div>
   </motion.div>
 );

--- a/components/common/ThemeToggle.tsx
+++ b/components/common/ThemeToggle.tsx
@@ -2,19 +2,10 @@
 
 import { Moon, Sun } from "lucide-react";
 import { useTheme } from "next-themes";
-import { useEffect, useState } from "react";
+
 
 export function ThemeToggle() {
   const { theme, setTheme } = useTheme();
-  const [mounted, setMounted] = useState(false);
-
-  useEffect(() => {
-    setMounted(true);
-  }, []);
-
-  if (!mounted) {
-    return null;
-  }
 
   return (
     <button


### PR DESCRIPTION
## Summary
- prefetch avatar image with `<Image priority>`
- render theme on initial load using a small script
- simplify `ThemeToggle` by removing mount check

## Testing
- `npm run lint` *(fails: `next: not found`)*